### PR TITLE
fix(ci): Add issues write permission to staleness workflow

### DIFF
--- a/.github/workflows/check-model-staleness.yml
+++ b/.github/workflows/check-model-staleness.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   check-staleness:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write  # Required for creating/listing issues
 
     steps:
       - name: Checkout code

--- a/scripts/create_new_prompt.py
+++ b/scripts/create_new_prompt.py
@@ -379,7 +379,9 @@ def validate_prompt_structure(prompt_dir: Path) -> bool:
                 print(f"⚠️  {filename}: Missing '## Prompt' section")
                 all_valid = False
             if "<task>" in content or "</task>" in content:
-                print(f"⚠️  {filename}: Contains model-specific XML tags (should be model-agnostic)")
+                print(
+                    f"⚠️  {filename}: Contains model-specific XML tags (should be model-agnostic)"
+                )
                 all_valid = False
             else:
                 print(f"✅ {filename}: Valid base prompt")

--- a/tests/test_model_updater/test_main.py
+++ b/tests/test_model_updater/test_main.py
@@ -31,8 +31,7 @@ def temp_repo_root(tmp_path: Path) -> Path:
 
     # Create a sample YAML file
     yaml_file = definitions_dir / "test-model.yaml"
-    yaml_file.write_text(
-        """model_id: test-model
+    yaml_file.write_text("""model_id: test-model
 provider: test
 name: Test Model
 api_identifier: test-v1
@@ -55,8 +54,7 @@ optimization:
   cost_tier: mid-tier
   speed_tier: balanced
 notes: "Test model"
-"""
-    )
+""")
 
     return tmp_path
 


### PR DESCRIPTION
## Summary
  - Add `issues: write` permission to check-model-staleness workflow
  - Fixes scheduled workflow failing with 'Resource not accessible by integration'

  ## Test plan
  - [ ] Manually trigger workflow from Actions tab
  - [ ] Verify job completes successfully

  🤖 Generated with [Claude Code](https://claude.com/claude-code)