### PR TITLE
chore(deps): Update openai requirement from >=1.12.0 to >=2.31.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 
 dependencies = [
     "anthropic>=0.18.0",
-    "openai>=1.12.0",
+    "openai>=2.31.0",
     "google-generativeai>=0.8.6",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Summary
- Replaces the closed dependabot PR #46, which it abandoned as "no longer updatable"
- Bumps the minimum openai constraint from `>=1.12.0` to `>=2.31.0` in `pyproject.toml`

Also addresses the label error Dependabot surfaced on #46 — the `dependencies` and `python` labels referenced in `.github/dependabot.yml` were missing from the repo. Both labels (plus `github-actions`) have now been created, so future Dependabot PRs will be labeled correctly.

## Test plan
- [ ] CI passes (lint, test 3.9–3.12, security, build)
- [ ] `pip install -e .` resolves against openai 2.31.x
- [ ] No runtime regressions in openai provider usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)