### PR TITLE
feat: Add pattern-interrupt detection to AI writing patterns prompt

### DIFF
--- a/prompts/stakeholder-communication/remove-ai-writing-patterns/prompt.claude.md
+++ b/prompts/stakeholder-communication/remove-ai-writing-patterns/prompt.claude.md
@@ -80,6 +80,109 @@ You are a writing coach helping transform AI-sounding content into natural, huma
   </detection_hints>
   <fix_strategy>Break the parallel structure. Consolidate the triad into a single sentence, or vary the sentence openers so the rhythm disappears. Example: "It is a missed close. It is an audit finding. It is a compliance exposure." → "A missed close becomes an audit finding and a compliance exposure."</fix_strategy>
 </pattern>
+
+<pattern id="clickbait_openers">
+  <name>Clickbait insight openers (pattern interrupts)</name>
+  <description>Windup phrases that promise a revelation before delivering one. The opener does the rhetorical work the sentence itself should do.</description>
+  <examples>
+    - "Here's the thing:", "Here's what's interesting:", "Here's the kicker:"
+    - "The dirty secret of X", "What nobody is talking about", "What they don't tell you"
+    - "Something clicked for me recently:", "This changed everything for me:"
+    - "The real reason X happens", "The true cost of X", "Why X actually fails"
+    - "Picture this:", "Imagine this:", "Stop me if you've heard this one"
+    - "Plot twist:", "Spoiler:", "Turns out,"
+    - "Let's be honest.", "Let's be real.", "The hard truth is...", "The uncomfortable truth..."
+    - "Hear me out", "Bear with me", "Think about it.", "Consider this:", "Food for thought."
+  </examples>
+  <fix_strategy>Delete the opener entirely and lead with the actual point. If the point cannot stand without the windup, the point is too weak. Example: "Here's the thing about modern finance: it's lean." → "Modern finance is lean."</fix_strategy>
+</pattern>
+
+<pattern id="fake_authority">
+  <name>Fake-authority credentialing</name>
+  <description>Vague appeals to experience that substitute for specific evidence.</description>
+  <examples>
+    - "After X years in this space...", "Having worked with hundreds of [founders/teams/customers]..."
+    - "I've talked to hundreds of founders and they all say the same thing:"
+    - "I've seen this movie before", "Trust me on this", "Take it from someone who's been there", "In the trenches"
+  </examples>
+  <fix_strategy>Cut the credential preamble. Make the claim directly. If credibility matters, earn it with a specific anecdote or data point, not a vague appeal to experience.</fix_strategy>
+</pattern>
+
+<pattern id="false_contrarianism">
+  <name>False contrarianism</name>
+  <description>Framing that pretends conventional wisdom is wrong before saying anything substantive. The parent form of the "not X, but Y" trap in negation_framing.</description>
+  <examples>
+    - "Contrary to popular belief", "Despite what you've been told", "Forget everything you know about X"
+    - "X isn't about Y. It's about Z."
+    - "And here's the part nobody wants to admit:", "What most people get wrong about X"
+  </examples>
+  <fix_strategy>State the actual claim. Skip the framing that pretends conventional wisdom is wrong before saying anything substantive.</fix_strategy>
+</pattern>
+
+<pattern id="empty_intensifiers">
+  <name>Empty intensifiers and false-modesty hedges</name>
+  <description>Adverbs that add no information, and hedges that signal humility without earning it.</description>
+  <examples>
+    - "Genuinely", "Truly", "Literally", "Quite literally"
+    - "I might be wrong, but...", "Take this with a grain of salt", "Your mileage may vary"
+  </examples>
+  <fix_strategy>Delete intensifiers (the sentence is stronger without them). Cut hedges unless you actually mean them.</fix_strategy>
+</pattern>
+
+<pattern id="engagement_bait_closers">
+  <name>Engagement-bait closers</name>
+  <description>Closing lines that solicit reader response or add false modesty.</description>
+  <examples>
+    - "What do you think?", "Let me know your thoughts.", "Drop a comment below."
+    - "Just my two cents.", "But that's just me."
+  </examples>
+  <fix_strategy>End on the substantive point. The reader can comment without being prompted.</fix_strategy>
+</pattern>
+
+<pattern id="tautology_closers">
+  <name>"X for X" tautology closers</name>
+  <description>Closers that sound profound but say nothing concrete.</description>
+  <examples>
+    - "A serious tool for serious work"
+    - "A real solution for real problems"
+    - "Built by builders for builders"
+  </examples>
+  <fix_strategy>Replace with a specific, concrete claim. The tautology sounds profound but says nothing.</fix_strategy>
+</pattern>
+
+<pattern id="anthropomorphized_abstractions">
+  <name>Anthropomorphized abstractions</name>
+  <description>Abstract nouns given human agency in place of a described mechanism.</description>
+  <examples>
+    - "A timeline that does not negotiate"
+    - "Deadlines that don't care"
+    - "Markets that punish"
+    - "Software that just works"
+  </examples>
+  <fix_strategy>Describe the actual mechanism or constraint. "The board meets Tuesday" beats "a timeline that does not negotiate."</fix_strategy>
+</pattern>
+
+<pattern id="punchy_paragraph_closers">
+  <name>Punchy single-sentence-paragraph closers</name>
+  <description>A short, declarative single-sentence paragraph used to "land" a point, deployed more than once in a piece.</description>
+  <examples>
+    - "That is the whole point."
+    - "Full stop."
+    - "End of story."
+    - "Period."
+  </examples>
+  <fix_strategy>One per piece, maximum. If the writing needs more than one to feel emphatic, the prose around them is too soft.</fix_strategy>
+</pattern>
+
+<pattern id="density_meta_check">
+  <name>Density meta-check (run this last)</name>
+  <description>Any single instance of the patterns above can read as human. Density is the tell.</description>
+  <detection_hints>
+    - Flag any piece where multiple categories (especially negation_framing, anaphoric_triads, clickbait_openers, punchy_paragraph_closers) appear more than twice each in under 1,500 words.
+    - Flag any section where three consecutive paragraphs each end on a punchy fragment or use the same rhetorical structure.
+  </detection_hints>
+  <fix_strategy>Vary cadence. Let some paragraphs end quietly. Let some claims arrive without setup or punctuation games.</fix_strategy>
+</pattern>
 </patterns_to_detect>
 
 <instructions>
@@ -117,9 +220,27 @@ You are a writing coach helping transform AI-sounding content into natural, huma
 <pattern_counts>
 <count pattern="negation_framing">N</count>
 <count pattern="excessive_em_dashes">N</count>
+<count pattern="hedge_words">N</count>
+<count pattern="meta_commentary">N</count>
+<count pattern="listicle_intros">N</count>
+<count pattern="bolded_list_leadins">N</count>
 <count pattern="anaphoric_triads">N</count>
-<!-- etc -->
+<count pattern="clickbait_openers">N</count>
+<count pattern="fake_authority">N</count>
+<count pattern="false_contrarianism">N</count>
+<count pattern="empty_intensifiers">N</count>
+<count pattern="engagement_bait_closers">N</count>
+<count pattern="tautology_closers">N</count>
+<count pattern="anthropomorphized_abstractions">N</count>
+<count pattern="punchy_paragraph_closers">N</count>
 </pattern_counts>
+
+<density_check>
+  <score>0-10 scale, where 10 = pervasive AI tells, 0 = clean</score>
+  <worst_section>Quote the section with the highest concentration of patterns</worst_section>
+  <flagged_categories>List categories appearing more than twice in under 1,500 words</flagged_categories>
+  <consecutive_punch_paragraphs>Note any run of 3+ paragraphs ending on punchy fragments or sharing rhetorical structure</consecutive_punch_paragraphs>
+</density_check>
 
 <alternative_phrasings>
 <alternative for="common pattern">

--- a/prompts/stakeholder-communication/remove-ai-writing-patterns/prompt.gemini.md
+++ b/prompts/stakeholder-communication/remove-ai-writing-patterns/prompt.gemini.md
@@ -48,11 +48,65 @@ Focus on these patterns:
    - Example: Change "It is a missed close. It is an audit finding. It is a compliance exposure." to "A missed close becomes an audit finding and a compliance exposure."
    - This is one of the strongest AI "tells" because humans rarely sustain this cadence naturally
 
+8. Clickbait insight openers (pattern interrupts)
+   - Pattern: "Here's the thing:", "Here's what's interesting:", "Here's the kicker:"
+   - Pattern: "The dirty secret of X", "What nobody is talking about", "What they don't tell you"
+   - Pattern: "Something clicked for me recently:", "This changed everything for me:"
+   - Pattern: "The real reason X happens", "The true cost of X", "Why X actually fails"
+   - Pattern: "Picture this:", "Imagine this:", "Stop me if you've heard this one"
+   - Pattern: "Plot twist:", "Spoiler:", "Turns out,"
+   - Pattern: "Let's be honest.", "Let's be real.", "The hard truth is...", "The uncomfortable truth..."
+   - Pattern: "Hear me out", "Bear with me", "Think about it.", "Consider this:", "Food for thought."
+   - Fix: Delete the opener entirely and lead with the actual point. If the point cannot stand without the windup, the point is too weak.
+   - Example: Change "Here's the thing about modern finance: it's lean." to "Modern finance is lean."
+
+9. Fake-authority credentialing
+   - Pattern: "After X years in this space...", "Having worked with hundreds of [founders/teams/customers]..."
+   - Pattern: "I've talked to hundreds of founders and they all say the same thing:"
+   - Pattern: "I've seen this movie before", "Trust me on this", "Take it from someone who's been there", "In the trenches"
+   - Fix: Cut the credential preamble. Make the claim directly. If credibility matters, earn it with a specific anecdote or data point, not a vague appeal to experience.
+
+10. False contrarianism
+    - Pattern: "Contrary to popular belief", "Despite what you've been told", "Forget everything you know about X"
+    - Pattern: "X isn't about Y. It's about Z." (the parent form of the "not X, but Y" trap in pattern #1)
+    - Pattern: "And here's the part nobody wants to admit:", "What most people get wrong about X"
+    - Fix: State the actual claim. Skip the framing that pretends conventional wisdom is wrong before saying anything substantive.
+
+11. Empty intensifiers and false-modesty hedges
+    - Pattern: "Genuinely", "Truly", "Literally", "Quite literally"
+    - Pattern: "I might be wrong, but...", "Take this with a grain of salt", "Your mileage may vary"
+    - Fix: Delete intensifiers (the sentence is stronger without them). Cut hedges unless you actually mean them.
+
+12. Engagement-bait closers
+    - Pattern: "What do you think?", "Let me know your thoughts.", "Drop a comment below."
+    - Pattern: "Just my two cents.", "But that's just me."
+    - Fix: End on the substantive point. The reader can comment without being prompted.
+
+13. "X for X" tautology closers
+    - Pattern: "A serious tool for serious work", "A real solution for real problems", "Built by builders for builders"
+    - Fix: Replace with a specific, concrete claim. The tautology sounds profound but says nothing.
+
+14. Anthropomorphized abstractions
+    - Pattern: "A timeline that does not negotiate", "Deadlines that don't care", "Markets that punish", "Software that just works"
+    - Fix: Describe the actual mechanism or constraint. "The board meets Tuesday" beats "a timeline that does not negotiate."
+
+15. Punchy single-sentence-paragraph closers
+    - Pattern: A short, declarative single-sentence paragraph used to "land" a point, deployed more than once in a piece.
+    - Pattern: "That is the whole point." "Full stop." "End of story." "Period."
+    - Fix: One per piece, maximum. If the writing needs more than one to feel emphatic, the prose around them is too soft.
+
+16. Density meta-check (run this last)
+    - Any single instance of the patterns above can read as human. Density is the tell.
+    - Flag any piece where multiple categories (especially #1, #7, #8, #15) appear more than twice each in under 1,500 words.
+    - Flag any section where three consecutive paragraphs each end on a punchy fragment or use the same rhetorical structure.
+    - Fix: Vary cadence. Let some paragraphs end quietly. Let some claims arrive without setup or punctuation games.
+
 Output format:
 - List each instance found with line/paragraph reference
 - Provide before/after diff for each
 - Explain why the change improves readability
 - Count total instances of each pattern
+- For pattern #16, provide a density score and flag the worst-offending section
 - Suggest 2-3 alternative phrasings when helpful
 
 Goal: Make writing sound more human, confident, and direct while preserving meaning and tone.

--- a/prompts/stakeholder-communication/remove-ai-writing-patterns/prompt.md
+++ b/prompts/stakeholder-communication/remove-ai-writing-patterns/prompt.md
@@ -70,11 +70,65 @@ Focus on these patterns:
    - Example: Change "It is a missed close. It is an audit finding. It is a compliance exposure." to "A missed close becomes an audit finding and a compliance exposure."
    - This is one of the strongest AI "tells" because humans rarely sustain this cadence naturally
 
+8. Clickbait insight openers (pattern interrupts)
+   - Pattern: "Here's the thing:", "Here's what's interesting:", "Here's the kicker:"
+   - Pattern: "The dirty secret of X", "What nobody is talking about", "What they don't tell you"
+   - Pattern: "Something clicked for me recently:", "This changed everything for me:"
+   - Pattern: "The real reason X happens", "The true cost of X", "Why X actually fails"
+   - Pattern: "Picture this:", "Imagine this:", "Stop me if you've heard this one"
+   - Pattern: "Plot twist:", "Spoiler:", "Turns out,"
+   - Pattern: "Let's be honest.", "Let's be real.", "The hard truth is...", "The uncomfortable truth..."
+   - Pattern: "Hear me out", "Bear with me", "Think about it.", "Consider this:", "Food for thought."
+   - Fix: Delete the opener entirely and lead with the actual point. If the point cannot stand without the windup, the point is too weak.
+   - Example: Change "Here's the thing about modern finance: it's lean." to "Modern finance is lean."
+
+9. Fake-authority credentialing
+   - Pattern: "After X years in this space...", "Having worked with hundreds of [founders/teams/customers]..."
+   - Pattern: "I've talked to hundreds of founders and they all say the same thing:"
+   - Pattern: "I've seen this movie before", "Trust me on this", "Take it from someone who's been there", "In the trenches"
+   - Fix: Cut the credential preamble. Make the claim directly. If credibility matters, earn it with a specific anecdote or data point, not a vague appeal to experience.
+
+10. False contrarianism
+    - Pattern: "Contrary to popular belief", "Despite what you've been told", "Forget everything you know about X"
+    - Pattern: "X isn't about Y. It's about Z." (the parent form of the "not X, but Y" trap in pattern #1)
+    - Pattern: "And here's the part nobody wants to admit:", "What most people get wrong about X"
+    - Fix: State the actual claim. Skip the framing that pretends conventional wisdom is wrong before saying anything substantive.
+
+11. Empty intensifiers and false-modesty hedges
+    - Pattern: "Genuinely", "Truly", "Literally", "Quite literally"
+    - Pattern: "I might be wrong, but...", "Take this with a grain of salt", "Your mileage may vary"
+    - Fix: Delete intensifiers (the sentence is stronger without them). Cut hedges unless you actually mean them.
+
+12. Engagement-bait closers
+    - Pattern: "What do you think?", "Let me know your thoughts.", "Drop a comment below."
+    - Pattern: "Just my two cents.", "But that's just me."
+    - Fix: End on the substantive point. The reader can comment without being prompted.
+
+13. "X for X" tautology closers
+    - Pattern: "A serious tool for serious work", "A real solution for real problems", "Built by builders for builders"
+    - Fix: Replace with a specific, concrete claim. The tautology sounds profound but says nothing.
+
+14. Anthropomorphized abstractions
+    - Pattern: "A timeline that does not negotiate", "Deadlines that don't care", "Markets that punish", "Software that just works"
+    - Fix: Describe the actual mechanism or constraint. "The board meets Tuesday" beats "a timeline that does not negotiate."
+
+15. Punchy single-sentence-paragraph closers
+    - Pattern: A short, declarative single-sentence paragraph used to "land" a point, deployed more than once in a piece.
+    - Pattern: "That is the whole point." "Full stop." "End of story." "Period."
+    - Fix: One per piece, maximum. If the writing needs more than one to feel emphatic, the prose around them is too soft.
+
+16. Density meta-check (run this last)
+    - Any single instance of the patterns above can read as human. Density is the tell.
+    - Flag any piece where multiple categories (especially #1, #7, #8, #15) appear more than twice each in under 1,500 words.
+    - Flag any section where three consecutive paragraphs each end on a punchy fragment or use the same rhetorical structure.
+    - Fix: Vary cadence. Let some paragraphs end quietly. Let some claims arrive without setup or punctuation games.
+
 Output format:
 - List each instance found with line/paragraph reference
 - Provide before/after diff for each
 - Explain why the change improves readability
 - Count total instances of each pattern
+- For pattern #16, provide a density score and flag the worst-offending section
 - Suggest 2-3 alternative phrasings when helpful
 
 Goal: Make writing sound more human, confident, and direct while preserving meaning and tone.

--- a/prompts/stakeholder-communication/remove-ai-writing-patterns/prompt.openai.md
+++ b/prompts/stakeholder-communication/remove-ai-writing-patterns/prompt.openai.md
@@ -48,11 +48,65 @@ Focus on these patterns:
    - Example: Change "It is a missed close. It is an audit finding. It is a compliance exposure." to "A missed close becomes an audit finding and a compliance exposure."
    - This is one of the strongest AI "tells" because humans rarely sustain this cadence naturally
 
+8. Clickbait insight openers (pattern interrupts)
+   - Pattern: "Here's the thing:", "Here's what's interesting:", "Here's the kicker:"
+   - Pattern: "The dirty secret of X", "What nobody is talking about", "What they don't tell you"
+   - Pattern: "Something clicked for me recently:", "This changed everything for me:"
+   - Pattern: "The real reason X happens", "The true cost of X", "Why X actually fails"
+   - Pattern: "Picture this:", "Imagine this:", "Stop me if you've heard this one"
+   - Pattern: "Plot twist:", "Spoiler:", "Turns out,"
+   - Pattern: "Let's be honest.", "Let's be real.", "The hard truth is...", "The uncomfortable truth..."
+   - Pattern: "Hear me out", "Bear with me", "Think about it.", "Consider this:", "Food for thought."
+   - Fix: Delete the opener entirely and lead with the actual point. If the point cannot stand without the windup, the point is too weak.
+   - Example: Change "Here's the thing about modern finance: it's lean." to "Modern finance is lean."
+
+9. Fake-authority credentialing
+   - Pattern: "After X years in this space...", "Having worked with hundreds of [founders/teams/customers]..."
+   - Pattern: "I've talked to hundreds of founders and they all say the same thing:"
+   - Pattern: "I've seen this movie before", "Trust me on this", "Take it from someone who's been there", "In the trenches"
+   - Fix: Cut the credential preamble. Make the claim directly. If credibility matters, earn it with a specific anecdote or data point, not a vague appeal to experience.
+
+10. False contrarianism
+    - Pattern: "Contrary to popular belief", "Despite what you've been told", "Forget everything you know about X"
+    - Pattern: "X isn't about Y. It's about Z." (the parent form of the "not X, but Y" trap in pattern #1)
+    - Pattern: "And here's the part nobody wants to admit:", "What most people get wrong about X"
+    - Fix: State the actual claim. Skip the framing that pretends conventional wisdom is wrong before saying anything substantive.
+
+11. Empty intensifiers and false-modesty hedges
+    - Pattern: "Genuinely", "Truly", "Literally", "Quite literally"
+    - Pattern: "I might be wrong, but...", "Take this with a grain of salt", "Your mileage may vary"
+    - Fix: Delete intensifiers (the sentence is stronger without them). Cut hedges unless you actually mean them.
+
+12. Engagement-bait closers
+    - Pattern: "What do you think?", "Let me know your thoughts.", "Drop a comment below."
+    - Pattern: "Just my two cents.", "But that's just me."
+    - Fix: End on the substantive point. The reader can comment without being prompted.
+
+13. "X for X" tautology closers
+    - Pattern: "A serious tool for serious work", "A real solution for real problems", "Built by builders for builders"
+    - Fix: Replace with a specific, concrete claim. The tautology sounds profound but says nothing.
+
+14. Anthropomorphized abstractions
+    - Pattern: "A timeline that does not negotiate", "Deadlines that don't care", "Markets that punish", "Software that just works"
+    - Fix: Describe the actual mechanism or constraint. "The board meets Tuesday" beats "a timeline that does not negotiate."
+
+15. Punchy single-sentence-paragraph closers
+    - Pattern: A short, declarative single-sentence paragraph used to "land" a point, deployed more than once in a piece.
+    - Pattern: "That is the whole point." "Full stop." "End of story." "Period."
+    - Fix: One per piece, maximum. If the writing needs more than one to feel emphatic, the prose around them is too soft.
+
+16. Density meta-check (run this last)
+    - Any single instance of the patterns above can read as human. Density is the tell.
+    - Flag any piece where multiple categories (especially #1, #7, #8, #15) appear more than twice each in under 1,500 words.
+    - Flag any section where three consecutive paragraphs each end on a punchy fragment or use the same rhetorical structure.
+    - Fix: Vary cadence. Let some paragraphs end quietly. Let some claims arrive without setup or punctuation games.
+
 Output format:
 - List each instance found with line/paragraph reference
 - Provide before/after diff for each
 - Explain why the change improves readability
 - Count total instances of each pattern
+- For pattern #16, provide a density score and flag the worst-offending section
 - Suggest 2-3 alternative phrasings when helpful
 
 Goal: Make writing sound more human, confident, and direct while preserving meaning and tone.


### PR DESCRIPTION
## Summary
- Adds nine new pattern categories (#8–16) to the Remove AI Writing Patterns prompt, targeting rhetorical tics that survive surface-level cleanup: clickbait insight openers, fake-authority credentialing, false contrarianism, empty intensifiers, engagement-bait closers, tautology closers, anthropomorphized abstractions, punchy single-sentence-paragraph closers, and a density meta-check.
- Updates all four provider variants (`prompt.md`, `prompt.claude.md`, `prompt.openai.md`, `prompt.gemini.md`) so the detection set stays consistent across Claude/OpenAI/Gemini.
- Adds a density score to the output format — single instances can pass, clusters get flagged. The Claude XML variant gets a dedicated `<density_check>` block (score, worst section, flagged categories, consecutive-punch-paragraph runs) and an expanded `<pattern_counts>` covering all 15 detection categories.

## Test plan
- [ ] Run the updated base prompt against a sample AI-generated draft and confirm patterns #8–16 are detected
- [ ] Run the Claude variant and confirm the `<density_check>` block is populated correctly
- [ ] Spot-check that previously detected patterns (#1–7) still surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)